### PR TITLE
add migrate cmd line that extend click-odoo-update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,3 +13,19 @@ Contributors
 ~~~~~~~~~~~~
 
 * Sébastien Beau <sebastien.beau@akretion.com>
+
+
+
+Binary tools
+============
+
+migrate
+~~~~~~~
+
+The migrate cmd line an extended version of **click-odoo-update**
+It have exactly the same behaviour but with two new features
+
+- for all modules in **odoo/local-src** migrations script inside the directory "migrations/0.0.0"
+  are always run
+- for the module custom_all you can add "before.sql" script and the request will be run before
+  the update of module

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# pylint: disable=print-used
+
+from click_odoo_contrib.update import main
+from odoo.modules.migration import MigrationManager
+from odoo.modules.registry import Registry
+from odoo import sql_db
+from datetime import datetime
+import os
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def get_version_last_digit(version):
+    return ".".join(version.split(".")[-3:])
+
+def get_new_version(current_version):
+    version = datetime.now().strftime("%y%m.%d.0")
+    # increment last digit if needed
+    if current_version >= version:
+        year_month, day, inc = current_version.split(".")
+        inc = str(int(inc) + 1)
+        version = ".".join([year_month, day, inc])
+    return version
+
+# Patch odoo native migration manager to always run migration script in the
+# directory "migrations/0.0.0"
+# Indeed odoo will only run the migration script if the version have been bump
+# inside the module.
+# So if an migration directory 0.0.0 exist "dynamically" increment the version
+# for odoo/local-src modules
+
+def have_pending_migration(self, pkg):
+    return bool(self.migrations[pkg.name].get("module", {}).get("0.0.0"))
+
+
+def update_version(pkg):
+    current_version = pkg.data["version"]
+    pkg.data["version"] = get_new_version(current_version)
+
+ori_migrate_module = MigrationManager.migrate_module
+
+def migrate_module(self, pkg, stage):
+    if have_pending_migration(self, pkg):
+        update_version(pkg)
+    return ori_migrate_module(self, pkg, stage)
+
+MigrationManager.migrate_module = migrate_module
+
+
+# Process before.sql script in custom_all/migrations/{version}/before.sql
+
+def get_before_request(cr):
+    cr.execute(
+        "SELECT latest_version FROM ir_module_module WHERE name='custom_all'"
+        )
+    todo = []
+    current_version = cr.fetchone()
+    if not current_version:
+        _logger.error("No version found for custom_all, skip begin script")
+    current_version = get_version_last_digit(current_version[0])
+    migr_path = "/odoo/local-src/custom_all/migrations"
+    if os.path.exists(migr_path):
+        for version in os.listdir(migr_path):
+            if version == "0.0.0" or version > current_version:
+                file_path = f"{migr_path}/{version}/before.sql"
+                if os.path.exists(file_path):
+                    todo.append((file_path, open(file_path, "r").read()))
+
+    return todo
+
+
+ori_new = Registry.new
+
+
+@classmethod
+def new(cls, db_name, force_demo=False, status=None, update_module=False):
+    conn = sql_db.db_connect(db_name)
+    with conn.cursor() as cr:
+        for file_path, requests in get_before_request(cr):
+            _logger.info("Execute before sql request \n===\n%s===\n", requests)
+            cr.execute(requests)
+    return ori_new(
+        db_name, force_demo=force_demo, status=status,
+        update_module=update_module)
+
+Registry.new = new
+
+
+# Call native click-odoo-update
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
@florian-dacosta @hparfr @PierrickBrun 

Here is the most minimal migration tools for replacing Marabunta.

## How to use it ?

Just use "migrate" instead of "click-odoo-update" (migrate will call click-odoo-update)

### If you want to do a PR with a migration script in a odoo/local-src module
just create a directory "migrations/0.0.0" in your module (do not care of the version)
=> your script will be run without need of defining a version


### If you have to run some sql request before running the migration
just create a file in "/odoo/local-src/custom_all/migrations/0.0.0/before.sql"
=> all sql request in this file will be execute before the loading of base module


### What do you think?

If there is no big objection, I propose to merge it here (later we can move this in a dedicated repo)
So we can test it in real condition and see if we still miss marabunta or not ?