### PR TITLE
[FIX] 12.0 ak build git version

### DIFF
--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -36,6 +36,14 @@ RUN set -x \
   && /env/bin/pip install -U pip wheel setuptools
 ENV PATH=/env/bin:$PATH
 
+# Install add-apt-repository command
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update \
+    && apt-get install -y --no-install-recommends software-properties-common
+
+# Allow to use latest git in ubuntu 18.04
+RUN add-apt-repository ppa:git-core/ppa
+
 RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update \
     && apt-get install -y --no-install-recommends $BUILD_PACKAGE


### PR DESCRIPTION
12.0 ubuntu version is 18.04, which has an older version of git. This version is not compatible with `git sparse-checkout`.