### PR TITLE
14.0 to py38 (py37 is EOL)

### DIFF
--- a/14.0/Dockerfile
+++ b/14.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/acsone/odoo-bedrock:14.0-py37-latest
+FROM ghcr.io/acsone/odoo-bedrock:14.0-py38-latest
 MAINTAINER Akretion
 
 # syntax = docker/dockerfile:1.4


### PR DESCRIPTION
Python 3.7 is End OF Life since June. Odoo 14.0 is known to work with Python 3.8 (it also uses 10% less memory and has a few optimizations compared with Python 3.7)

I'm not sure how much I can prove Odoo 14 works with Python 3.8, but we have been testing it extensively on 3.8 for more than 1 year with OCA/l10n-brazil https://github.com/OCA/l10n-brazil/blob/14.0/.github/workflows/test.yml#L38 and Acsone recently proposed 3.8 as the default Python version for odoo-shopinvader. Not sure how people could eventually valid this change in their project before we could merge it.

cc @hparfr @sebastienbeau @PierrickBrun 