### PR TITLE
fixes a bash syntax error with BUILD_RESTRICT_LANG and some English

### DIFF
--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/acsone/odoo-bedrock:12.0-py37-latest
-MAINTAINER Akretion
+LABEL maintainer=Akretion
 
 # syntax = docker/dockerfile:1.4
 

--- a/13.0/Dockerfile
+++ b/13.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/acsone/odoo-bedrock:13.0-py37-latest
-MAINTAINER Akretion
+LABEL maintainer=Akretion
 
 # syntax = docker/dockerfile:1.4
 

--- a/14.0/Dockerfile
+++ b/14.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/acsone/odoo-bedrock:14.0-py38-latest
-MAINTAINER Akretion
+LABEL maintainer=Akretion
 
 # syntax = docker/dockerfile:1.4
 

--- a/15.0/Dockerfile
+++ b/15.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/acsone/odoo-bedrock:15.0-py38-latest
-MAINTAINER Akretion
+LABEL maintainer=Akretion
 
 # syntax = docker/dockerfile:1.4
 

--- a/16.0/Dockerfile
+++ b/16.0/Dockerfile
@@ -1,6 +1,6 @@
 # python 3.10 is the default used in acsone
 FROM ghcr.io/acsone/odoo-bedrock:16.0-py310-latest
-MAINTAINER Akretion
+LABEL maintainer=Akretion
 
 # syntax = docker/dockerfile:1.4
 

--- a/bin/ak-entrypoint.sh
+++ b/bin/ak-entrypoint.sh
@@ -15,7 +15,7 @@ export DB_NAME=${PGDATABASE}
 
 
 if [ -z "$(pip list --format=columns | grep "/odoo/src")" ]; then
-  # The build runs 'pip install -e' on the odoo src, which creates an
+  # The build runs 'pip install -e' on the odoo/src directory, which creates an
   # odoo.egg-info directory *inside /odoo/src*. So when we run a container
   # with a volume shared with the host, we don't have this .egg-info (at least
   # the first time).
@@ -30,7 +30,7 @@ if [ -z "$(pip list --format=columns | grep "/odoo/src")" ]; then
   chown -R $USER_ID:$USER_ID /odoo/src/*.egg-info
 fi
 
-# Do not block the entrypoint if the pip install fail (only local case)
-# so we only exist if fail after the pip install
+# Do not block the entrypoint if pip install fails (only local case)
+# so we only exit in case of a failure after pip install
 set -Eeuo pipefail
 /usr/local/bin/entrypoint.sh "$@"

--- a/install/build-odoo
+++ b/install/build-odoo
@@ -8,17 +8,16 @@ ak build -c odoo-spec.yaml -f odoo-frozen.yaml
 # Remove useless git directory
 rm -rf /odoo/src/.git
 
-# Keep only wanted odoo module if defined
+# First, we eventually keep only the wanted odoo modules
 if [ -z "$(ls -A /odoo/links)" ]; then
-  echo "No module specify, display all"
+  echo "No addons set specified, keeping all addons"
 else
   cp -r -L /odoo/links /odoo/odoo-addons
   rm -rf /odoo/src/addons/*
   mv /odoo/odoo-addons/* /odoo/src/addons
 fi
 
-# Secondly we remove unwanted lang
-if [[ BUILD_RESTRICT_LANG ]]
-then
+# Second, we remove unwanted lang
+if [[ -n "$BUILD_RESTRICT_LANG" ]]; then
     find /odoo/src/ -name *.po ! -name $BUILD_RESTRICT_LANG -type f -exec rm -v {} +
 fi


### PR DESCRIPTION
as for BUILD_RESTRICT_LANG, you can try not setting BUILD_RESTRICT_LANG in your odoo/Dockerfile and the build will fail. Now it works again (if [[ "-n $SOME_ENV_VAR" ]] is the proper way to avoid blank values as well https://stackoverflow.com/a/14900557 )

Also, I inform you I fixed the bad "rebuild the world" we experience once a week on the CI after Acsone updates the bedrock  base image weekly. I used a multi-steps build image, I'll create other PRs for it. It will save the Akretion CI from downloading over 200 Gb from Github every week easily... And also saves a solid ~6Gb weekly per deploy to the production servers...
We couldn't live with that with our bandwidth limitations in Brazil...

cc @sebastienbeau @hparfr @PierrickBrun 

