### PR TITLE
set /odoo as default dir

### DIFF
--- a/14.0-light/Dockerfile
+++ b/14.0-light/Dockerfile
@@ -36,4 +36,5 @@ RUN pip install --no-cache-dir -r /tmp/base_requirements.txt
 COPY 14.0-light/ak_requirements.txt /tmp/ak_requirements.txt
 RUN pip install --no-cache-dir -r /tmp/ak_requirements.txt
 
+WORKDIR /odoo
 CMD ["odoo"]

--- a/16.0-light/Dockerfile
+++ b/16.0-light/Dockerfile
@@ -36,4 +36,5 @@ RUN pip install --no-cache-dir -r /tmp/base_requirements.txt
 COPY 16.0-light/ak_requirements.txt /tmp/ak_requirements.txt
 RUN pip install --no-cache-dir -r /tmp/ak_requirements.txt
 
+WORKDIR /odoo
 CMD ["odoo"]

--- a/17.0-light/Dockerfile
+++ b/17.0-light/Dockerfile
@@ -35,4 +35,5 @@ RUN pip install --no-cache-dir -r /tmp/base_requirements.txt
 COPY 17.0-light/ak_requirements.txt /tmp/ak_requirements.txt
 RUN pip install --no-cache-dir -r /tmp/ak_requirements.txt
 
+WORKDIR /odoo
 CMD ["odoo"]


### PR DESCRIPTION
Align with v18 and v19
It's also an alternative fix than pip compat_mode=editable