### PR TITLE
Fix entrypoint use exec

### DIFF
--- a/bin/ak-entrypoint.sh
+++ b/bin/ak-entrypoint.sh
@@ -33,4 +33,4 @@ fi
 # Do not block the entrypoint if the pip install fail (only local case)
 # so we only exist if fail after the pip install
 set -Eeuo pipefail
-/usr/local/bin/entrypoint.sh "$@"
+exec /usr/local/bin/entrypoint.sh "$@"


### PR DESCRIPTION
When using exec the odoo process will replace the shell process. So the main odoo process will have the PID 1.
When executing docker stop, docker send a SIGTERM to the process 1. If odoo do not have the right PID, the stop will fail and docker will send a SIGKILL.
Now stopping a container will stop odoo correctly.